### PR TITLE
Set Default Theme Mode

### DIFF
--- a/astro-blog/src/components/DarkModeToggle.astro
+++ b/astro-blog/src/components/DarkModeToggle.astro
@@ -39,9 +39,9 @@
   // Initialize theme on page load
   function initTheme() {
     const savedTheme = localStorage.getItem('theme');
-    const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
 
-    if (savedTheme === 'dark' || (!savedTheme && systemPrefersDark)) {
+    // Default to dark mode unless explicitly set to light
+    if (savedTheme !== 'light') {
       setTheme('dark');
     } else {
       setTheme('light');

--- a/astro-blog/src/layouts/Layout.astro
+++ b/astro-blog/src/layouts/Layout.astro
@@ -66,9 +66,9 @@ const {
       // Initialize theme before page renders to prevent flash
       (function() {
         const savedTheme = localStorage.getItem('theme');
-        const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
 
-        if (savedTheme === 'dark' || (!savedTheme && systemPrefersDark)) {
+        // Default to dark mode unless explicitly set to light
+        if (savedTheme !== 'light') {
           document.documentElement.classList.add('dark');
         }
       })();


### PR DESCRIPTION
Updated theme initialization logic to default to dark mode instead of light mode. Users can still manually switch to light mode, which will be saved in localStorage.

Changes:
- Modified Layout.astro to set dark mode as default
- Updated DarkModeToggle.astro initialization to match
- Removed system preference fallback, dark is now the default for new visitors